### PR TITLE
New, faster flow

### DIFF
--- a/deprecated.go
+++ b/deprecated.go
@@ -16,7 +16,6 @@ func (s *Ssg) build() ([]OutputFile, error) {
 	// returning the results as []write.
 	//
 	// build also caches the result in s for [WriteOut] later.
-	// deprecated
 
 	err := filepath.WalkDir(s.Src, s.walkScan)
 	if err != nil {
@@ -34,6 +33,7 @@ func (s *Ssg) build() ([]OutputFile, error) {
 func (s *Ssg) walkScan(path string, d fs.DirEntry, err error) error {
 	// walkScan scans the source directory for header and footer files,
 	// and anything required to build a page.
+
 	if err != nil {
 		return err
 	}
@@ -92,6 +92,7 @@ func (s *Ssg) walkScan(path string, d fs.DirEntry, err error) error {
 func (s *Ssg) walkBuild(path string, d fs.DirEntry, err error) error {
 	// walkBuild finds and converts Markdown files to HTML,
 	// and assembles it with header and footer.
+
 	if err != nil {
 		return err
 	}

--- a/deprecated.go
+++ b/deprecated.go
@@ -1,0 +1,125 @@
+package ssg
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// Code here is deprecated but kept as handy reference
+
+// deprecated
+func (s *Ssg) build() ([]OutputFile, error) {
+	// build walks the src directory, and converts Markdown into HTML,
+	// returning the results as []write.
+	//
+	// build also caches the result in s for [WriteOut] later.
+	// deprecated
+
+	err := filepath.WalkDir(s.Src, s.walkScan)
+	if err != nil {
+		return nil, err
+	}
+	err = filepath.WalkDir(s.Src, s.walkBuild)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.dist, nil
+}
+
+// deprecated
+func (s *Ssg) walkScan(path string, d fs.DirEntry, err error) error {
+	// walkScan scans the source directory for header and footer files,
+	// and anything required to build a page.
+	if err != nil {
+		return err
+	}
+
+	base := filepath.Base(path)
+	ignore, err := shouldIgnore(s.ssgignores, path, base, d)
+	if err != nil {
+		return err
+	}
+	if ignore {
+		return nil
+	}
+
+	// Collect cascading headers and footers
+	switch base {
+	case MarkerHeader:
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+
+		err = s.headers.add(filepath.Dir(path), header{
+			Buffer:    bytes.NewBuffer(data),
+			titleFrom: GetTitleFrom(data),
+		})
+		if err != nil {
+			return err
+		}
+
+		return nil
+
+	case MarkerFooter:
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		err = s.footers.add(filepath.Dir(path), bytes.NewBuffer(data))
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	if filepath.Ext(base) != ".html" {
+		return nil
+	}
+	if s.preferred.Insert(path) {
+		return fmt.Errorf("duplicate html file %s", path)
+	}
+
+	return nil
+}
+
+// deprecated
+func (s *Ssg) walkBuild(path string, d fs.DirEntry, err error) error {
+	// walkBuild finds and converts Markdown files to HTML,
+	// and assembles it with header and footer.
+	if err != nil {
+		return err
+	}
+
+	base := filepath.Base(path)
+	ignore, err := shouldIgnore(s.ssgignores, path, base, d)
+	if err != nil {
+		return err
+	}
+	if ignore {
+		return nil
+	}
+
+	switch base {
+	case
+		MarkerHeader,
+		MarkerFooter:
+		return nil
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	if s.impl != nil {
+		return s.impl(path, data, d)
+	}
+
+	return s.implDefault(path, data, d)
+}

--- a/options.go
+++ b/options.go
@@ -42,13 +42,13 @@ func ParallelWritesEnv() Option {
 // GetEnvParallelWrites returns ENV value for parallel writes,
 // or default value if illgal or undefined
 func GetEnvParallelWrites() int {
-	writesEnv := os.Getenv(parallelWritesEnvKey)
+	writesEnv := os.Getenv(ParallelWritesEnvKey)
 	writes, err := strconv.ParseUint(writesEnv, 10, 32)
 	if err == nil && writes != 0 {
 		return int(writes)
 	}
 
-	return parallelWritesDefault
+	return ParallelWritesDefault
 }
 
 // WithHookAll will make [Ssg] call f(path, fileContent)

--- a/soyweb/index_test.go
+++ b/soyweb/index_test.go
@@ -13,6 +13,11 @@ func TestGenerateIndex(t *testing.T) {
 	src := "./testdata/myblog/src"
 	dst := "./testdata/myblog/dst"
 
+	err := os.RemoveAll(dst)
+	if err != nil {
+		panic(err)
+	}
+
 	markers := map[string][]string{
 		"_index.ssg": {
 			`<li><p><a href="/2023/">2023</a></p></li>`,
@@ -39,7 +44,7 @@ func TestGenerateIndex(t *testing.T) {
 		}
 	}
 
-	err := ssg.Generate(src, dst, "TestTitle", "https://my.blog", IndexGenerator())
+	err = ssg.Generate(src, dst, "TestTitle", "https://my.blog", IndexGenerator())
 	if err != nil {
 		t.Fatalf("error during ssg generation: %v", err)
 	}

--- a/soyweb/testdata/johndoe.com/src/testconvert/_header.html
+++ b/soyweb/testdata/johndoe.com/src/testconvert/_header.html
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
 
-<!-- NOTES HEADER -->
+<!-- Header for testconvert -->
 
 <head>
     <meta charset="UTF-8">
-    <title>{{from-tag}}</title>
+    <title>{{from-h1}}</title>
 </head>
 
 <body>

--- a/ssg.go
+++ b/ssg.go
@@ -323,7 +323,7 @@ func (s *Ssg) collect(path string) error {
 		}
 
 		ext := filepath.Ext(base)
-		if ext == ".md" {
+		if ext != ".html" {
 			continue
 		}
 

--- a/ssg.go
+++ b/ssg.go
@@ -236,6 +236,23 @@ func (s *Ssg) WriteOut() error {
 	return nil
 }
 
+// build walks the src directory, and converts Markdown into HTML,
+// returning the results as []write.
+//
+// build also caches the result in s for [WriteOut] later.
+func (s *Ssg) build() ([]OutputFile, error) {
+	err := filepath.WalkDir(s.Src, s.walkScan)
+	if err != nil {
+		return nil, err
+	}
+	err = filepath.WalkDir(s.Src, s.walkBuild)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.dist, nil
+}
+
 func (s *Ssg) buildV2() ([]OutputFile, error) {
 	err := filepath.WalkDir(s.Src, s.walkBuildV2)
 	if err != nil {
@@ -250,7 +267,6 @@ func (s *Ssg) walkBuildV2(path string, d fs.DirEntry, err error) error {
 		return err
 	}
 	if d.IsDir() {
-		fmt.Println("collecting", path)
 		return s.collect(path)
 	}
 
@@ -333,23 +349,6 @@ func (s *Ssg) collect(path string) error {
 	}
 
 	return nil
-}
-
-// build walks the src directory, and converts Markdown into HTML,
-// returning the results as []write.
-//
-// build also caches the result in s for [WriteOut] later.
-func (s *Ssg) build() ([]OutputFile, error) {
-	err := filepath.WalkDir(s.Src, s.walkScan)
-	if err != nil {
-		return nil, err
-	}
-	err = filepath.WalkDir(s.Src, s.walkBuild)
-	if err != nil {
-		return nil, err
-	}
-
-	return s.dist, nil
 }
 
 // walkScan scans the source directory for header and footer files,

--- a/ssg_test.go
+++ b/ssg_test.go
@@ -1,11 +1,13 @@
 package ssg
 
 import (
+	"bytes"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/sabhiram/go-gitignore"
+	ignore "github.com/sabhiram/go-gitignore"
 )
 
 func TestToHTML(t *testing.T) {
@@ -133,15 +135,34 @@ Some paragraph2`,
 	}
 }
 
-func TestScan(t *testing.T) {
+func TestGenerate(t *testing.T) {
+	t.Run("build-v1", func(t *testing.T) {
+		testGenerate(t, func(s *Ssg) ([]OutputFile, error) {
+			return s.build()
+		})
+	})
+
+	t.Run("build-v2", func(t *testing.T) {
+		testGenerate(t, func(s *Ssg) ([]OutputFile, error) {
+			return s.buildV2()
+		})
+	})
+}
+
+func testGenerate(t *testing.T, buildFn func(s *Ssg) ([]OutputFile, error)) {
 	root := "./soyweb/testdata/johndoe.com"
 	src := filepath.Join(root, "/src")
 	dst := filepath.Join(root, "/dst")
 	title := "JohnDoe.com"
 	url := "https://johndoe.com"
 
+	err := os.RemoveAll(dst)
+	if err != nil {
+		panic(err)
+	}
+
 	s := New(src, dst, title, url)
-	err := filepath.WalkDir(root, s.walkScan)
+	outputs, err := buildFn(&s)
 	if err != nil {
 		t.Errorf("unexpected error from scan: %v", err)
 	}
@@ -160,32 +181,113 @@ func TestScan(t *testing.T) {
 		}
 	}
 
-	headers := map[string]TitleFrom{
+	titleFroms := map[string]TitleFrom{
 		"/_header.html":           TitleFromH1,
 		"/blog/_header.html":      TitleFromTag,
 		"/blog/2023/_header.html": TitleFromNone,
 	}
 
-	for h, from := range headers {
+	for h, from := range titleFroms {
 		filename := filepath.Join(src, h)
 		dirname := filepath.Dir(filename)
-
 		header, ok := s.headers.perDir.values[dirname]
 		if !ok {
 			t.Fatalf("missing header '%s' for dir '%s'", filename, dirname)
 		}
-
 		if header.titleFrom != from {
 			t.Fatalf("unexpected from '%d', expecting %d", header.titleFrom, from)
 		}
+	}
+
+	type expected struct {
+		subString string
+		titleFrom TitleFrom
+	}
+
+	expecteds := map[string]expected{
+		"/": {
+			titleFrom: TitleFromH1,
+			subString: "<!-- ROOT HEADER -->",
+		},
+		"/blog": {
+			titleFrom: TitleFromTag,
+			subString: "<!-- HEADER FOR BLOG -->",
+		},
+		"/blog/": {
+			titleFrom: TitleFromTag,
+			subString: "<!-- HEADER FOR BLOG -->",
+		},
+		"/blog/2022": {
+			titleFrom: TitleFromTag,
+			subString: "<!-- HEADER FOR BLOG -->",
+		},
+		"/blog/2022/3": {
+			titleFrom: TitleFromTag,
+			subString: "<!-- HEADER FOR BLOG -->",
+		},
+		"/blog/2023": {
+			titleFrom: TitleFromNone,
+			subString: "<!-- HEADER FOR BLOG 2023 -->",
+		},
+		"/notes": {
+			titleFrom: TitleFromTag,
+			subString: "<!-- NOTES HEADER -->",
+		},
+	}
+
+	for parentDir, e := range expecteds {
+		parentDir = filepath.Join(src, parentDir)
+		chosen := s.headers.choose(parentDir)
+		if chosen.titleFrom != e.titleFrom {
+			t.Fatalf("unexpected titleFrom at dir '%s' actual=%d, expecting=%d", parentDir, chosen.titleFrom, e.titleFrom)
+		}
+		if !bytes.Contains(chosen.Bytes(), []byte(e.subString)) {
+			t.Fatalf("missing expecting substr '%s' from dir %s", e.subString, parentDir)
+		}
+	}
+
+	expectedOutputs := map[string][]string{
+		"/index.html": {
+			"<title>Welcome to JohnDoe.com!</title>",
+		},
+		"/blog/2022/index.html": {
+			"<title>2022 Blog index</title>",
+			"<body><h1 id=\"blog-from-the-worst-year\">Blog from the worst year</h1>",
+		},
+		"/testconvert/index.html": {
+			"<!-- Header for testconvert -->",
+			"<title>Embedded-HTML should be correctly preserved</title>",
+		},
+	}
+
+	for path, e := range expectedOutputs {
+		path = filepath.Join(dst, path)
+		for i := range outputs {
+			o := &outputs[i]
+			if o.target != path {
+				continue
+			}
+			for j := range e {
+				s := e[j]
+				if bytes.Contains(o.data, []byte(s)) {
+					continue
+				}
+				t.Fatalf("missing expected substr '%s' from output %s", s, o.target)
+			}
+		}
+	}
+
+	err = os.RemoveAll(dst)
+	if err != nil {
+		panic(err)
 	}
 }
 
 // Test that the library we use actually does what we want it to
 func TestSsgignore(t *testing.T) {
 	type testCase struct {
-		ignores  []string
 		path     string
+		ignores  []string
 		expected bool
 	}
 


### PR DESCRIPTION
New drop-in replacement build method `ssg.Ssg.buildV2` that will walk the source directory exactly once.