### PR TITLE
Streaming outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 > This repository also hosts [soyweb](./soyweb/),
 > an ssg wrapper and replacement for [webtools](https://github.com/soyart/webtools)
 
-
 This Nix Flake provides 2 implementations of ssg.
 
 - POSIX shell ssg
@@ -32,8 +31,8 @@ This Nix Flake provides 2 implementations of ssg.
 
 ## Build from Nix flake
 
-```
-nix build # Build default package - pure POSIX shell ssg
+```sh
+nix build          # Build default package - pure POSIX shell ssg
 nix build .#impure # Build directly from ssg.sh
 nix build .#ssg-go # Build Go implementation of ssg
 nix build .#soyweb # Build soyweb programs
@@ -185,10 +184,10 @@ Then:
 
 ### Concurrent writes and environment variable
 
-ssg-go allows users to configure concurrent write goroutines (green threads).
+ssg-go allows users to configure concurrent writer goroutines (green threads).
 
-ssg-go by default writes 20 files concurrently. This concurrent threads can
-be configured by setting env `SSG_PARALLEL_WRITES` to a non-zero positive integer.
+ssg-go, by default, writes out to 20 files concurrently. The number of concurrent
+threads are configured by setting env `SSG_PARALLEL_WRITES` to a non-zero positive integer.
 
 If the env value is illegal, ssg-go falls back to 20 concurrent write threads.
 
@@ -200,7 +199,7 @@ SSG_PARALLEL_WRITES=1 ssg mySrc myDst myTitle myUrl
 
 # Extending ssg-go
 
-ssg-go defines its API via `Option` for extending its usefulness.
+Go programmers can extend ssg-go via its `Option` type.
 
-[soyweb](./soyweb/) extends ssg via `Option`, and provide extra functionality
-such as index generator and minifiers.
+[soyweb](./soyweb/) extends ssg via `Option`,
+and provide extra functionality such as index generator and minifiers.

--- a/cmd/ssg-streaming/main.go
+++ b/cmd/ssg-streaming/main.go
@@ -21,7 +21,7 @@ func main() {
 		ssg.WriteStreaming(),
 	)
 
-	err := s.GenerateStreaming()
+	err := s.Generate()
 	if err != nil {
 		fmt.Fprintln(os.Stdout, "error with", "src", src, "dst", dst, "title", title, "url", url)
 		panic(err)

--- a/cmd/ssg-streaming/main.go
+++ b/cmd/ssg-streaming/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/soyart/ssg"
+)
+
+func main() {
+	if len(os.Args) < 5 {
+		fmt.Fprint(os.Stdout, "usage: ssg src dst title base_url\n")
+		syscall.Exit(1)
+	}
+
+	src, dst, title, url := os.Args[1], os.Args[2], os.Args[3], os.Args[4]
+	s := ssg.New(src, dst, title, url)
+	s.With(
+		ssg.ParallelWritesEnv(),
+		ssg.WriteStreaming(),
+	)
+
+	err := s.GenerateStreaming()
+	if err != nil {
+		fmt.Fprintln(os.Stdout, "error with", "src", src, "dst", dst, "title", title, "url", url)
+		panic(err)
+	}
+}

--- a/cmd/ssg-streaming/main.go
+++ b/cmd/ssg-streaming/main.go
@@ -18,7 +18,7 @@ func main() {
 	s := ssg.New(src, dst, title, url)
 	s.With(
 		ssg.ParallelWritesEnv(),
-		ssg.WriteStreaming(),
+		ssg.Streaming(),
 	)
 
 	err := s.Generate()

--- a/options.go
+++ b/options.go
@@ -52,9 +52,9 @@ func GetEnvParallelWrites() int {
 	return ParallelWritesDefault
 }
 
-func WriteStreaming() Option {
+func Streaming() Option {
 	return func(s *Ssg) {
-		s.streaming.c = make(chan OutputFile)
+		s.streaming.enabled = true
 	}
 }
 

--- a/options.go
+++ b/options.go
@@ -58,6 +58,12 @@ func Streaming() Option {
 	}
 }
 
+func ParallelWrites(u uint) Option {
+	return func(s *Ssg) {
+		s.parallelWrites = int(u)
+	}
+}
+
 // WithHookAll will make [Ssg] call f(path, fileContent)
 // on every unignored files.
 func WithHookAll(f HookAll) Option {

--- a/options.go
+++ b/options.go
@@ -23,10 +23,10 @@ type (
 	Impl func(path string, data []byte, d fs.DirEntry) error
 
 	options struct {
-		hookAll      HookAll
-		hookGenerate HookGenerate
-		streaming
+		hookAll        HookAll
+		hookGenerate   HookGenerate
 		impl           Impl
+		streaming      streaming
 		parallelWrites int
 	}
 )

--- a/options.go
+++ b/options.go
@@ -26,6 +26,7 @@ type (
 		hookAll        HookAll
 		hookGenerate   HookGenerate
 		impl           Impl
+		streaming      chan OutputFile
 		parallelWrites int
 	}
 )
@@ -49,6 +50,12 @@ func GetEnvParallelWrites() int {
 	}
 
 	return ParallelWritesDefault
+}
+
+func WriteStreaming() Option {
+	return func(s *Ssg) {
+		s.streaming = make(chan OutputFile)
+	}
 }
 
 // WithHookAll will make [Ssg] call f(path, fileContent)

--- a/options.go
+++ b/options.go
@@ -23,10 +23,10 @@ type (
 	Impl func(path string, data []byte, d fs.DirEntry) error
 
 	options struct {
-		hookAll        HookAll
-		hookGenerate   HookGenerate
+		hookAll      HookAll
+		hookGenerate HookGenerate
+		streaming
 		impl           Impl
-		streaming      chan OutputFile
 		parallelWrites int
 	}
 )
@@ -54,7 +54,7 @@ func GetEnvParallelWrites() int {
 
 func WriteStreaming() Option {
 	return func(s *Ssg) {
-		s.streaming = make(chan OutputFile)
+		s.streaming.c = make(chan OutputFile)
 	}
 }
 

--- a/ssg.go
+++ b/ssg.go
@@ -167,16 +167,22 @@ func (s *Ssg) With(opts ...Option) *Ssg {
 }
 
 func (s *Ssg) Generate() error {
-	if s.streaming.c != nil {
+	if s.streaming.enabled {
 		return s.generateStreaming()
 	}
 	return s.generate()
 }
 
 func (s *Ssg) generate() error {
+	if s.streaming.enabled {
+		panic("streaming is enabled")
+	}
+	if s.streaming.c != nil {
+		panic("streaming channel is not nil")
+	}
+
 	// Reset
 	s.dist = nil
-
 	stat, err := os.Stat(s.Src)
 	if err != nil {
 		return err

--- a/ssg.go
+++ b/ssg.go
@@ -149,6 +149,13 @@ xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
 }
 
 func (s *Ssg) AddOutputs(outputs ...OutputFile) {
+	if s.streaming != nil {
+		for i := range outputs {
+			s.streaming <- outputs[i]
+		}
+		return
+	}
+
 	s.dist = append(s.dist, outputs...)
 }
 

--- a/ssg.go
+++ b/ssg.go
@@ -61,9 +61,7 @@ type Ssg struct {
 // Generate creates a one-off [Ssg] that's used to generate a site right away.
 func Generate(src, dst, title, url string, opts ...Option) error {
 	s := New(src, dst, title, url)
-	return s.
-		With(opts...).
-		Generate()
+	return s.With(opts...).Generate()
 }
 
 // New returns a default, vanilla [Ssg].
@@ -72,7 +70,6 @@ func New(src, dst, title, url string) Ssg {
 	if err != nil {
 		panic(err)
 	}
-
 	return Ssg{
 		Src:        src,
 		Dst:        dst,
@@ -91,20 +88,19 @@ func ToHtml(md []byte) []byte {
 	renderer := html.NewRenderer(html.RendererOptions{
 		Flags: HtmlFlags,
 	})
-
 	return markdown.Render(root, renderer)
 }
 
 func Sitemap(
 	dst string,
 	url string,
-	date time.Time,
+	modTime time.Time,
 	outputs []OutputFile,
 ) (
 	string,
 	error,
 ) {
-	dateStr := date.Format(time.DateOnly)
+	dateStr := modTime.Format(time.DateOnly)
 	sm := bytes.NewBufferString(`<?xml version="1.0" encoding="UTF-8"?>
 <urlset
 xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"
@@ -155,7 +151,6 @@ func (s *Ssg) AddOutputs(outputs ...OutputFile) {
 		}
 		return
 	}
-
 	s.dist = append(s.dist, outputs...)
 }
 
@@ -248,7 +243,6 @@ func (s *Ssg) WriteOut() error {
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 
@@ -341,7 +335,6 @@ func (s *Ssg) collect(path string) error {
 			if err != nil {
 				return err
 			}
-
 			continue
 
 		case MarkerFooter:
@@ -353,7 +346,6 @@ func (s *Ssg) collect(path string) error {
 			if err != nil {
 				return err
 			}
-
 			continue
 		}
 
@@ -575,7 +567,6 @@ func (o *OutputFile) modeOutput() fs.FileMode {
 	if o.perm == fs.FileMode(0) {
 		return fs.ModePerm
 	}
-
 	return o.perm
 }
 

--- a/streaming.go
+++ b/streaming.go
@@ -18,14 +18,13 @@ func (s *Ssg) generateStreaming() error {
 		panic("streaming not enabled")
 	}
 
-	s.streaming.c = make(chan OutputFile)
-
 	stat, err := os.Stat(s.Src)
 	if err != nil {
 		return fmt.Errorf("failed to stat src '%s': %w", s.Src, err)
 	}
 
 	var wg sync.WaitGroup
+	s.streaming.c = make(chan OutputFile, s.parallelWrites*2)
 
 	var errBuild error
 	wg.Add(1)

--- a/streaming.go
+++ b/streaming.go
@@ -10,13 +10,15 @@ import (
 
 type streaming struct {
 	c       chan OutputFile
-	outputs []string
+	enabled bool
 }
 
 func (s *Ssg) generateStreaming() error {
-	if s.streaming.c == nil {
-		panic("nil streaming channel")
+	if !s.streaming.enabled {
+		panic("streaming not enabled")
 	}
+
+	s.streaming.c = make(chan OutputFile)
 
 	stat, err := os.Stat(s.Src)
 	if err != nil {
@@ -76,9 +78,11 @@ func (s *Ssg) generateStreaming() error {
 		return err
 	}
 
+	s.pront(len(dist) + 2)
 	return nil
 }
 
+// WriteOutStreaming blocks and concurrently writes outputs from c until c is closed.
 func WriteOutStreaming(c <-chan OutputFile, parallelWrites int) ([]string, error) {
 	if parallelWrites == 0 {
 		parallelWrites = ParallelWritesDefault

--- a/streaming.go
+++ b/streaming.go
@@ -1,0 +1,111 @@
+package ssg
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+func (s *Ssg) GenerateStreaming() error {
+	if s.streaming == nil {
+		panic("nil streaming channel")
+	}
+
+	var wg sync.WaitGroup
+
+	var errGen error
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		dist, err := s.buildV2()
+		if err != nil {
+			errGen = err
+		}
+		if len(dist) != 0 {
+			panic("dist is not empty")
+		}
+
+		close(s.streaming)
+	}()
+
+	var errWrites error
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := WriteOutStreaming(s.streaming, s.parallelWrites)
+		if err != nil {
+			errWrites = err
+		}
+	}()
+
+	wg.Wait()
+
+	if errGen != nil {
+		return errGen
+	}
+	if errWrites != nil {
+		return errWrites
+	}
+
+	return nil
+}
+
+func WriteOutStreaming(c <-chan OutputFile, parallelWrites int) error {
+	if parallelWrites == 0 {
+		parallelWrites = ParallelWritesDefault
+	}
+
+	wg := new(sync.WaitGroup)
+	errs := make(chan writeError)
+	guard := make(chan struct{}, parallelWrites)
+
+	for o := range c {
+		guard <- struct{}{}
+		wg.Add(1)
+
+		go func(w *OutputFile, wg *sync.WaitGroup) {
+			defer func() {
+				<-guard
+				wg.Done()
+			}()
+
+			err := os.MkdirAll(filepath.Dir(w.target), os.ModePerm)
+			if err != nil {
+				errs <- writeError{
+					err:    err,
+					target: w.target,
+				}
+				return
+			}
+
+			err = os.WriteFile(w.target, w.data, w.modeOutput())
+			if err != nil {
+				errs <- writeError{
+					err:    err,
+					target: w.target,
+				}
+				return
+			}
+
+			fmt.Fprintln(os.Stdout, w.target)
+
+		}(&o, wg)
+	}
+
+	go func() {
+		wg.Wait()
+		close(errs)
+	}()
+
+	var wErrs []error
+	for err := range errs { // Blocks here until errs is closed
+		wErrs = append(wErrs, err)
+	}
+	if len(wErrs) > 0 {
+		return errors.Join(wErrs...)
+	}
+
+	return nil
+}

--- a/streaming.go
+++ b/streaming.go
@@ -111,7 +111,6 @@ func WriteOutStreaming(c <-chan OutputFile, parallelWrites int) ([]string, error
 				}
 				return
 			}
-
 			err = os.WriteFile(w.target, w.data, w.modeOutput())
 			if err != nil {
 				errs <- writeError{

--- a/streaming_test.go
+++ b/streaming_test.go
@@ -29,7 +29,7 @@ func TestStreaming(t *testing.T) {
 
 	s := New(src, dst, title, url)
 	streaming := New(src, dstStreaming, title, url)
-	streaming.With(WriteStreaming())
+	streaming.With(Streaming())
 
 	err = s.Generate()
 	if err != nil {

--- a/streaming_test.go
+++ b/streaming_test.go
@@ -1,0 +1,108 @@
+package ssg
+
+import (
+	"bytes"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestStreaming tests that all files are
+// properly flushed to destination when streaming
+func TestStreaming(t *testing.T) {
+	root := "./soyweb/testdata/johndoe.com"
+	src := filepath.Join(root, "/src")
+	dst := filepath.Join(root, "/dstNoStreaming")
+	dstStreaming := filepath.Join(root, "/dstStreaming")
+	title := "JohnDoe.com"
+	url := "https://johndoe.com"
+
+	err := os.RemoveAll(dst)
+	if err != nil {
+		panic(err)
+	}
+	err = os.RemoveAll(dstStreaming)
+	if err != nil {
+		panic(err)
+	}
+
+	s := New(src, dst, title, url)
+	streaming := New(src, dstStreaming, title, url)
+	streaming.With(WriteStreaming())
+
+	err = s.Generate()
+	if err != nil {
+		panic(err)
+	}
+
+	err = streaming.Generate()
+	if err != nil {
+		t.Fatalf("error generating with streaming: %v", err)
+	}
+
+	filepath.WalkDir(s.Dst, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(dst, path)
+		if err != nil {
+			panic(err)
+		}
+
+		pathStreaming := filepath.Join(streaming.Dst, rel)
+
+		if d.IsDir() {
+			entries, err := os.ReadDir(path)
+			if err != nil {
+				return err
+			}
+			entriesStreaming, err := os.ReadDir(pathStreaming)
+			if err != nil {
+				return err
+			}
+			if l, ls := len(entries), len(entriesStreaming); l != ls {
+				for i := range entries {
+					t.Logf("expected entry for %s: %s", path, entries[i].Name())
+				}
+				t.Fatalf("unexpected len of entries in '%s': expected=%d, actual=%d", pathStreaming, l, ls)
+			}
+
+			for i := range entries {
+				name := entries[i].Name()
+				nameStreaming := entriesStreaming[i].Name()
+				if name != nameStreaming {
+					t.Fatalf("unexpected filename '%s'", nameStreaming)
+				}
+			}
+
+			return nil
+		}
+
+		stat, err := os.Stat(path)
+		if err != nil {
+			panic(err)
+		}
+		statStreaming, err := os.Stat(pathStreaming)
+		if err != nil {
+			t.Fatalf("unexpected error from stat '%s': %v", pathStreaming, err)
+		}
+		if sz, szStreaming := stat.Size(), statStreaming.Size(); sz != szStreaming {
+			t.Fatalf("unexpected size from '%s': expected=%d, actual=%d", pathStreaming, sz, szStreaming)
+		}
+
+		bytesExpected, err := os.ReadFile(path)
+		if err != nil {
+			panic(err)
+		}
+		bytesStreaming, err := os.ReadFile(pathStreaming)
+		if err != nil {
+			t.Fatalf("unexpected error from reading '%s'", pathStreaming)
+		}
+		if !bytes.Equal(bytesExpected, bytesStreaming) {
+			t.Fatalf("unexpected bytes from '%s'", pathStreaming)
+		}
+
+		return nil
+	})
+}

--- a/streaming_test.go
+++ b/streaming_test.go
@@ -8,12 +8,12 @@ import (
 	"testing"
 )
 
-// TestStreaming tests that all files are
-// properly flushed to destination when streaming
+// TestStreaming tests that all files are properly flushed to destination when streaming,
+// and that all outputs are identical
 func TestStreaming(t *testing.T) {
 	root := "./soyweb/testdata/johndoe.com"
 	src := filepath.Join(root, "/src")
-	dst := filepath.Join(root, "/dstNoStreaming")
+	dst := filepath.Join(root, "/dst")
 	dstStreaming := filepath.Join(root, "/dstStreaming")
 	title := "JohnDoe.com"
 	url := "https://johndoe.com"
@@ -27,21 +27,18 @@ func TestStreaming(t *testing.T) {
 		panic(err)
 	}
 
-	s := New(src, dst, title, url)
-	streaming := New(src, dstStreaming, title, url)
-	streaming.With(Streaming())
-
-	err = s.Generate()
+	// Generate without streaming
+	err = Generate(src, dst, title, url)
 	if err != nil {
 		panic(err)
 	}
-
-	err = streaming.Generate()
+	// Generate with streaming
+	err = Generate(src, dst, title, url, Streaming())
 	if err != nil {
 		t.Fatalf("error generating with streaming: %v", err)
 	}
 
-	filepath.WalkDir(s.Dst, func(path string, d fs.DirEntry, err error) error {
+	filepath.WalkDir(dst, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
@@ -50,7 +47,7 @@ func TestStreaming(t *testing.T) {
 			panic(err)
 		}
 
-		pathStreaming := filepath.Join(streaming.Dst, rel)
+		pathStreaming := filepath.Join(dstStreaming, rel)
 
 		if d.IsDir() {
 			entries, err := os.ReadDir(path)

--- a/streaming_test.go
+++ b/streaming_test.go
@@ -28,12 +28,17 @@ func TestStreaming(t *testing.T) {
 	}
 
 	// Generate without streaming
-	err = Generate(src, dst, title, url)
+	err = Generate(src, dst, title, url,
+		ParallelWrites(uint(ParallelWritesDefault)),
+	)
 	if err != nil {
 		panic(err)
 	}
 	// Generate with streaming
-	err = Generate(src, dst, title, url, Streaming())
+	err = Generate(src, dstStreaming, title, url,
+		ParallelWrites(uint(ParallelWritesDefault)),
+		Streaming(),
+	)
 	if err != nil {
 		t.Fatalf("error generating with streaming: %v", err)
 	}


### PR DESCRIPTION
# As-is: concurrent writes

ssg-go currently walks the source tree, builds output files, and stores it in memory for the rest of the runtime. Once the whole directory walk is over, ssg-go sends the in-memory outputs to a concurrent writer.

This is good for simplicity and predictability, but may raise memory usage concerns on very large inputs

# To-be: concurrent build and writes

This PR adds a new `ssg.Option` that allows ssg-go to build and write out to files concurrently. This reduces memory usage for using ssg-go with very large inputs, and may enable ssg-go to run on systems with lower memory.