### PR TITLE
Fix GitHub Actions: Nix Flake fails to build soyweb

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,9 @@ on:
     types: [created]
 
   push:
+    branches:
+      - 'poc/cicd'
+
     tags:
       - 'v*'
       - 'dev-*'
@@ -23,9 +26,18 @@ jobs:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build ssg-go from flake
-        run: 'nix build .#ssg-go'
+        run: |
+          nix build .#ssg-go
 
-      - name: Zip built binaries
+      - name: Zip ssg-go binaries
+        run: |
+          zip -r ssg-go-x86_64_linux.zip result/bin
+
+      - name: Build soyweb from flake
+        run: |
+          nix build .#soyweb
+
+      - name: Zip soyweb binaries
         run: |
           zip -r ssg-go-x86_64_linux.zip result/bin
 


### PR DESCRIPTION
`nix build` complains about mismatching hash strings. If we run `nix build .#soyweb` locally, the build passes and the hash seems to be valid.

I suspect it's because the GitHub Actions runner might have differing files in the root repository on each workflow run, changing the hash to something else.