### PR TITLE
Fix: bad header/footer

### DIFF
--- a/soyweb/cmd/ssg-test-impl/main.go
+++ b/soyweb/cmd/ssg-test-impl/main.go
@@ -1,16 +1,33 @@
 package main
 
 import (
+	"os"
+
 	"github.com/soyart/ssg"
 	"github.com/soyart/ssg/soyweb"
 )
 
 func main() {
+	src := "./testdata/myblog/src"
+	dst := "./testdata/myblog/dst-cmd"
+	title := "TestIndexGeneratorCMD"
+	url := "https://myblog.com"
+
+	if len(os.Args) >= 2 {
+		src = os.Args[1]
+	}
+	if len(os.Args) >= 3 {
+		dst = os.Args[2]
+	}
+	if len(os.Args) >= 4 {
+		title = os.Args[3]
+	}
+	if len(os.Args) >= 5 {
+		title = os.Args[4]
+	}
+
 	err := ssg.Generate(
-		"./testdata/myblog/src",
-		"./testdata/myblog/dst",
-		"TestIndexGenerator",
-		"https://myblog.com",
+		src, dst, title, url,
 		soyweb.IndexGenerator(),
 	)
 	if err != nil {

--- a/soyweb/cmd/ssg-test-impl/main.go
+++ b/soyweb/cmd/ssg-test-impl/main.go
@@ -7,8 +7,8 @@ import (
 
 func main() {
 	err := ssg.Generate(
-		"testdata/myblog/src",
-		"testdata/myblog/dst",
+		"./testdata/myblog/src",
+		"./testdata/myblog/dst",
 		"TestIndexGenerator",
 		"https://myblog.com",
 		soyweb.IndexGenerator(),

--- a/soyweb/index_test.go
+++ b/soyweb/index_test.go
@@ -1,6 +1,7 @@
 package soyweb
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -12,6 +13,8 @@ import (
 func TestGenerateIndex(t *testing.T) {
 	src := "./testdata/myblog/src"
 	dst := "./testdata/myblog/dst"
+	title := "TestTitle"
+	defaultTitleHtml := fmt.Sprintf("<title>%s</title>", title)
 
 	err := os.RemoveAll(dst)
 	if err != nil {
@@ -20,23 +23,25 @@ func TestGenerateIndex(t *testing.T) {
 
 	markers := map[string][]string{
 		"_index.soyweb": {
-			// `<title>My blog (title tag)</title>`,
+			`<title>My blog (title tag)</title>`,
 			`<li><p><a href="/2023/">2023</a></p></li>`,
 			`<li><p><a href="/2022/">2022</a></p></li>`,
 		},
 		"2022/_index.soyweb": {
-			`Index of 2022`,
+			`<title>twenty and twenty-two (from-tag)</title>`,
 			`<li><p><a href="/2022/bar/">bar</a></p></li>`,
 			`<li><p><a href="/2022/foo.html">Foo</a></p></li>`,
 		},
 		"2023/_index.soyweb": {
-			`Index of 2023`,
+			defaultTitleHtml,
+			`Index of 2023`, // because _index.soyweb was empty
 			`<li><p><a href="/2023/baz.html">Bazketball</a></p></li>`,
 			`<li><p><a href="/2023/recurse/">recurse</a></p></li>`,
 			`<li><p><a href="/2023/lol/">LOLOLOL</a></p></li>`,
 		},
 		"2023/recurse/_index.soyweb": {
-			`<title>Recurse Index</title>`,
+			defaultTitleHtml,
+			`<h1 id="recurse-index">Recurse Index</h1>`,
 			"<li><p><a href=\"/2023/recurse/r1/\">Recursive 1</a></p></li>",
 			"<li><p><a href=\"/2023/recurse/r2/\">Recursive 2</a></p></li>",
 		},

--- a/soyweb/testdata/myblog/src/2022/_index.soyweb
+++ b/soyweb/testdata/myblog/src/2022/_index.soyweb
@@ -1,0 +1,4 @@
+:ssg-title twenty and twenty-two (from-tag)
+
+# 2022 blog!
+

--- a/ssg.go
+++ b/ssg.go
@@ -228,7 +228,11 @@ func DotFiles(dst string, dist []OutputFile) (string, error) {
 }
 
 func (s *Ssg) buildV2() ([]OutputFile, error) {
-	err := filepath.WalkDir(s.Src, s.walkBuildV2)
+	rel, err := filepath.Rel(".", s.Src) // Eliminate preceding './', so that chooser will not be confused
+	if err != nil {
+		return nil, err
+	}
+	err = filepath.WalkDir(rel, s.walkBuildV2)
 	if err != nil {
 		return nil, err
 	}

--- a/ssg.go
+++ b/ssg.go
@@ -76,10 +76,13 @@ func Generate(src, dst, title, url string, opts ...Option) error {
 
 // New returns a default, vanilla [Ssg].
 func New(src, dst, title, url string) Ssg {
+	src = filepath.Clean(src)
+	dst = filepath.Clean(dst)
 	ignores, err := prepare(src, dst)
 	if err != nil {
 		panic(err)
 	}
+
 	return Ssg{
 		Src:        src,
 		Dst:        dst,
@@ -228,11 +231,7 @@ func DotFiles(dst string, dist []OutputFile) (string, error) {
 }
 
 func (s *Ssg) buildV2() ([]OutputFile, error) {
-	rel, err := filepath.Rel(".", s.Src) // Eliminate preceding './', so that chooser will not be confused
-	if err != nil {
-		return nil, err
-	}
-	err = filepath.WalkDir(rel, s.walkBuildV2)
+	err := filepath.WalkDir(s.Src, s.walkBuildV2)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When paths start with `./`, i.e. `./foo` instead of `foo`, the perDir selector might not be able to find corresponding header or footer.

This PR fixes that