### PR TITLE
Refactor and simplify index generator

### DIFF
--- a/.github/workflows/test-ssg-go.yaml
+++ b/.github/workflows/test-ssg-go.yaml
@@ -19,6 +19,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    env:
+      ARTIFACT_SSG_GO: "ssg-go-test_result-go${{ matrix.go-version }}_${{ matrix.os }}.json"
+      ARTIFACT_SOYWEB: "soyweb-test_result-go${{ matrix.go-version }}_${{ matrix.os }}.json"
     steps:
       - name: Checkout code
         uses: actions/checkout@master
@@ -33,12 +36,22 @@ jobs:
           cache: false
           check-latest: true
 
-      - name: Test with Go
-        run: go test -json ./... > ssg-go-test_result-go${{ matrix.go-version }}_${{ matrix.os }}.json
+      - name: Test ssg-go
+        run: |
+          echo Testing soyweb and writing JSON report to $ARTIFACT_SSG_GO
+          go test -race -count=1 -json ./... > $ARTIFACT_SSG_GO
+
+      - name: Test soyweb
+        run: |
+          echo Testing soyweb and writing JSON report to $ARTIFACT_SOYWEB
+          cd ./soyweb/
+          go test -race -count=1 -json ./... > $ARTIFACT_SOYWEB
 
       - name: Upload Go test results
         uses: actions/upload-artifact@v4
         with:
-          name: ssg-go-test_result-go${{ matrix.go-version }}_${{ matrix.os }}
-          path: ssg-go-test_result-go${{ matrix.go-version }}_${{ matrix.os }}.json
+          name: test_result-go${{ matrix.go-version }}_${{ matrix.os }}
+          path: |
+            ${{ env.ARTIFACT_SSG_GO }}
+            soyweb/${{ env.ARTIFACT_SOYWEB }}
 

--- a/README.md
+++ b/README.md
@@ -205,18 +205,18 @@ ssg-go falls back to 20 concurrent writers.
 There're 2 main ssg threads: one is for building the outputs,
 and the other is the write thread.
 
-The main thread *sequentially* reads and sends outputs to the write
-thread via a buffered Go channel.
+The build thread *sequentially* reads, builds and sends outputs
+to the write thread via a buffered Go channel.
 
 Bufffering allows the builder thread to continue to build and send outputs
 to the writer until the buffer is full.
 
+This helps reduce back pressure, and keeps memory usage low.
+The buffer size is, by default, 2x of the number of writers.
+
 This means that, at any point in time during a generation of any number of files
 with 20 writers, ssg-go will at most only hold 40 output files
 in memory (in the buffered channel).
-
-This helps reduce back pressure, and keeps memory usage low.
-The buffer size is, by default, 2x of the number of writers.
 
 If you are importing ssg-go to your code and you don't want this
 streaming behavior, you can use the exposed function `Build`, `WriteOut`,
@@ -262,6 +262,9 @@ soyweb uses this option to implement output minifier.
 To reduce complexity, ignored files and ssg headers/footers are not sent
 to `Impl`. This preserves the core functionality of the original ssg.
 
+An example of `Impl` would be the [index generator](./index.go),
+which intercept all unignored files
+
 > When using `Impl`, `HookAll` or `HookGenerate` are not called
 > unless explicitly called in the Impl.
 >
@@ -273,5 +276,4 @@ to `Impl`. This preserves the core functionality of the original ssg.
 > If it needs to generate an index, then it creates a new output file,
 > and passes that to the standard ssg-go implementation, allowing all
 > the features such as header/footer combination and hooks to continue to work.
-
 

--- a/generate_test.go
+++ b/generate_test.go
@@ -15,7 +15,7 @@ func generateCaching(s *Ssg) error {
 	if err != nil {
 		return err
 	}
-	dist, err := s.buildV2()
+	files, dist, err := s.buildV2()
 	if err != nil {
 		return err
 	}
@@ -23,7 +23,7 @@ func generateCaching(s *Ssg) error {
 	if err != nil {
 		return err
 	}
-	err = GenerateMetadata(s.Url, s.Dst, dist, stat.ModTime())
+	err = GenerateMetadata(s.Src, s.Dst, s.Url, files, dist, stat.ModTime())
 	if err != nil {
 		return err
 	}

--- a/soyweb/README.md
+++ b/soyweb/README.md
@@ -1,21 +1,20 @@
 # soyweb
 
-soyweb is a collection of ssg-go wrapper and extensions.
-
-At the core, soyweb uses [ssg-go](https://github.com/soyart/ssg)
-of [ssg](https://romanzolotarev.com/ssg.html) to convert Markdown files
-into HTML files.
+soyweb is a collection of [ssg-go](https://github.com/soyart/ssg)
+wrappers and extensions.
 
 soyweb extensions respect ssg-go quirks such as ssgignore,
-header and footer handling, preference of source HTML files over Markdown,
-file permissions, etc.
+handling of header and footer templates, preference of source HTML files
+over the Markdown, file permissions, etc.
+
+## soyweb programs
 
 In addition to extension library, soyweb provides a few programs that
 serve as a collection of tools meant to replace [webtools](https://github.com/soyart/webtools).
 The main purpose is to build [artnoi.com](https://artnoi.com) with a single binary
 to streamline the site's CI/CD pipelines.
 
-> Most of these programs share the same CLI flags, and the help messagee
+> Most of these programs share the same CLI flags, and the help messages
 > can be accessible via `-h` or `--help`
 
 - [minifier](./cmd/minifier)
@@ -119,16 +118,18 @@ to streamline the site's CI/CD pipelines.
     ssg-manifest copy -h
     ```
 
-# ssg options provided by soyweb
+## soyweb ssg-go options
 
-## Minifiers
+soyweb extends ssg-go options using `ssg.Option` type.
 
-soyweb provides webformat minifiers opitions for ssg, implemented as hooks that
-map 1 input data to 1 output data.
+### Minifiers
+
+soyweb provides webformat minifiers opitions for ssg, implemented as
+hooks that map 1 input data to 1 output data.
 
 The minifiers is available to all programs under soyweb.
 
-## [Index generator](./index.go)
+### [Index generator](./index.go)
 
 soyweb provides an [ssg.Impl](/options.go) that will automatically generate index
 for blog directories. It scans for marker file `_index.soyweb`, and, if found,
@@ -153,46 +154,71 @@ ssg-go input files.
 
 The generator is currently available to `ssg-manifest` via the site manifest specification.
 
-### Index generator title extraction
+#### Index generator: how it's generated
+
+The generated indexes are treated just like any other source Markdown files.
 
 In other words, `_header.html` and `_footer.html` will surround the index generated from
 marker files. [`ssg.TitleFrom`](../title.go) tags are respected and title extraction
 for the generated index is handled in the familiar fashion.
 
-The only quirks with the generator is that, in the index entries, child titles are extracted
-from `:ssg-title` tag first, and if there's no such title, then the first Markdown h1 (`# FooTitle`)
-will be picked as the child title *within* the index.
+#### Index generator: link title extraction (files)
 
-### Index generator practical examples
+Only Markdown and HTML siblings are to be linked. For example, if we have 2 files
+`1.md` and `2.html`, then links will be generated for `1.html` and `2.html`.
 
-For example, consider ssg source directory `src`:
+Link titles are extracted from tag `:ssg-title` first (`:ssg-title FooTitle`),
+and if there's no such title, then the generator falls back to Markdown h1 titles
+(`# FooTitle`) will be picked as the child title *within* the index.
+
+#### Index generator: link title extraction (directories)
+
+If a marker's sibling is a directory with `index.md`, then the titles will be extracted
+from the Markdown index like with files.
+
+If there's no `index.md`, then the directory names will be used as titles. And instead
+of linking to `/some/path/targetdir/index.md`, the directory links ends with a slash,
+so `/some/path/targetdir/` is the hyperlink generated.
+
+#### Index generator: practical examples
+
+Consider a ssg source directory `src`:
 
 ```
 src
+│
+├── _footer.html
+├── _header.html
+├── _index.soyweb
+│
+├── foo.md
+├── bar.md
+│
 ├── 2022
 │   ├── _index.soyweb
 │   ├── lol.md
 │   └── not_article.svg
+│
 ├── 2023
 │   ├── hahaha
 │   │   └── index.md
 │   ├── _index.soyweb
 │   └── baz.md
-├── _footer.html
-├── _header.html
-├── _index.soyweb
+│
 └── somedir
+    └── index.md
 ```
 
 We see 3 markers, in `src`, `src/2022`, and `src/2023`. This means
 that we should get 3 generated `index.html`s. But we also see that
 `src/2022/index.html` already exists.
 
-This means that ssg will not pass the `src/2022/_index.soyweb` to
-the generator, and only 2 indexes will be generated.
+Because ssg-go gives preferences to HTML files with matching base names,
+and because the generator respects this behavior, the source HTML will be
+copied and new index not generated.
 
-Let us first focus on the root marker. We see that there're 3 top-level children,
-namely, `2022`, `2023`, `somedir`.
+If we focus on the root marker. We see that it has 5 siblings, namely,
+`foo.md`, `bar.md`, `2022`, `2023`, and `somedir`.
 
 The generated index should have links to these 3 children.
 If the destination is `dst`, then the generated index from this root marker
@@ -224,12 +250,40 @@ We can look up the special ssg files so that we can compare the output:
 `src/_index.soyweb`:
 
 ```markdown
-:ssg-title FooTitle
+:ssg-title My blog!
 
 # Welcome to my blog!
 
 Below is the list of my articles!
 
+```
+
+`src/foo.md`:
+
+```
+# Foo article
+
+Foo is better than fu
+```
+
+`src/bar.md`:
+
+```
+:ssg-title Bar article
+
+# Barbarbarbar
+
+Greeks called other peoples babarians because all they hear is barbarbar
+```
+
+`src/somedir/index.md`:
+
+```markdown
+:ssg-title SomeDir title
+
+# Welcome to SomeDir!
+
+This is some directory
 ```
 
 Now, the generated index `dst/index.html` looks like this:
@@ -240,7 +294,7 @@ Now, the generated index `dst/index.html` looks like this:
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>FooTitle</title>
+<title>My blog!</title>
 </head>
 <body>
 <h1>Welcome to my blog!</h1>
@@ -248,6 +302,8 @@ Now, the generated index `dst/index.html` looks like this:
 <ul>
   <li><p><a href="/2023/">2023</a></p></li>
   <li><p><a href="/2022/">2022</a></p></li>
+  <li><p><a href="/bar.html">Bar article</a></p></li>
+  <li><p><a href="/foo.html">Foo article</a></p></li>
   <li><p><a href="/somedir/">SomeDir title</a></p></li>
 </ul>
 <!-- My blog footer! -->
@@ -261,7 +317,7 @@ to the root marker example above.
 
 But what if the marker `src/2023/_index.soyweb` is empty?
 If so, then the default heading will be used, and the generated
-`dst/2023/index.html` looks like this:
+`dst/2023/index.html` looks something like this:
 
 ```html
 <!-- My blog header! -->
@@ -269,7 +325,7 @@ If so, then the default heading will be used, and the generated
 <html lang="en">
 <head>
 <meta charset="UTF-8">
-<title>SomeDefaultTitle</title>
+<title>SomeDefaultSsgGoTitle</title>
 </head>
 <body>
 <h1>Index of somedir</h1>

--- a/soyweb/cmd/minifier/main.go
+++ b/soyweb/cmd/minifier/main.go
@@ -75,15 +75,16 @@ func (m *minifier) minify() ([]ssg.OutputFile, error) {
 		return m.dist, nil
 	}
 
-	output, err := soyweb.MinifyFile(m.src)
+	data, err := os.ReadFile(m.src)
 	if err != nil {
-		output, err = os.ReadFile(m.src)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
+	}
+	output, err := soyweb.MinifyAll(m.src, data)
+	if err != nil {
+		output = data
 	}
 
-	out := ssg.Output(m.dst, output, stat.Mode().Perm())
+	out := ssg.Output(m.dst, m.src, output, stat.Mode().Perm())
 	return []ssg.OutputFile{out}, nil
 }
 
@@ -110,7 +111,7 @@ func (m *minifier) walk(path string, d fs.DirEntry, e error) error {
 			return err
 		}
 
-		m.dist = append(m.dist, ssg.Output(dst, copied, info.Mode().Perm()))
+		m.dist = append(m.dist, ssg.Output(dst, path, copied, info.Mode().Perm()))
 		return nil
 	}
 
@@ -119,6 +120,6 @@ func (m *minifier) walk(path string, d fs.DirEntry, e error) error {
 		return err
 	}
 
-	m.dist = append(m.dist, ssg.Output(dst, minified, info.Mode().Perm()))
+	m.dist = append(m.dist, ssg.Output(dst, path, minified, info.Mode().Perm()))
 	return nil
 }

--- a/soyweb/index.go
+++ b/soyweb/index.go
@@ -83,7 +83,7 @@ func genIndex(
 
 		isDir := sib.IsDir()
 		sibExt := filepath.Ext(sibName)
-		if !isDir && sibExt != ".md" {
+		if !isDir && (sibExt != ".md" && sibExt != ".html") {
 			continue
 		}
 
@@ -137,7 +137,7 @@ func genIndex(
 				linkTitle = string(title)
 			}
 
-		case sibExt == ".md":
+		case sibExt == ".md" || sibExt == ".html":
 			title, err := extractTitle(sibPath)
 			if err != nil {
 				return "", err
@@ -145,8 +145,9 @@ func genIndex(
 			if len(title) != 0 {
 				linkTitle = string(title)
 			}
-
-			sibName = ssg.ChangeExt(sibName, ".md", ".html")
+			if sibExt == ".md" {
+				sibName = ssg.ChangeExt(sibName, ".md", ".html")
+			}
 
 		default:
 			panic("unhandled case for child: " + filepath.Join(parent, sibName))

--- a/ssg.go
+++ b/ssg.go
@@ -218,6 +218,7 @@ func DotFiles(dst string, dist []OutputFile) (string, error) {
 		if err != nil {
 			return "", err
 		}
+		// TODO: use original file that results in this output
 		// Replace Markdown extension
 		if filepath.Ext(path) == ".html" {
 			path = ChangeExt(path, ".html", ".md")

--- a/ssg.go
+++ b/ssg.go
@@ -220,8 +220,7 @@ func DotFiles(dst string, dist []OutputFile) (string, error) {
 		}
 		// Replace Markdown extension
 		if filepath.Ext(path) == ".html" {
-			path = strings.TrimSuffix(path, ".html")
-			path += ".md"
+			path = ChangeExt(path, ".html", ".md")
 		}
 
 		Fprintf(list, "./%s\n", path)
@@ -351,11 +350,9 @@ func (s *Ssg) implDefault(path string, data []byte, d fs.DirEntry) error {
 		return nil
 	}
 
-	// Make way for existing (preferred) html file with matching base name
-	html := strings.TrimSuffix(path, ".md")
-	html += ".html"
+	html := ChangeExt(path, ".md", ".html")
 	if s.preferred.ContainsAll(html) {
-		return nil
+		return nil // Make way for existing (preferred) html file with matching base name
 	}
 
 	target, err := MirrorPath(s.Src, s.Dst, path, ".html")
@@ -505,8 +502,7 @@ func MirrorPath(
 ) {
 	ext := filepath.Ext(path)
 	if ext != newExt {
-		path = strings.TrimSuffix(path, ext)
-		path += newExt
+		path = ChangeExt(path, ext, newExt)
 	}
 	path, err := filepath.Rel(src, path)
 	if err != nil {

--- a/ssg_test.go
+++ b/ssg_test.go
@@ -137,13 +137,13 @@ Some paragraph2`,
 
 func TestGenerate(t *testing.T) {
 	t.Run("build-v2", func(t *testing.T) {
-		testGenerate(t, func(s *Ssg) ([]OutputFile, error) {
+		testGenerate(t, func(s *Ssg) ([]string, []OutputFile, error) {
 			return s.buildV2()
 		})
 	})
 }
 
-func testGenerate(t *testing.T, buildFn func(s *Ssg) ([]OutputFile, error)) {
+func testGenerate(t *testing.T, buildFn func(s *Ssg) ([]string, []OutputFile, error)) {
 	root := "./soyweb/testdata/johndoe.com"
 	src := filepath.Join(root, "/src")
 	dst := filepath.Join(root, "/dst")
@@ -156,7 +156,7 @@ func testGenerate(t *testing.T, buildFn func(s *Ssg) ([]OutputFile, error)) {
 	}
 
 	s := New(src, dst, title, url)
-	outputs, err := buildFn(&s)
+	_, outputs, err := buildFn(&s)
 	if err != nil {
 		t.Errorf("unexpected error from scan: %v", err)
 	}
@@ -397,7 +397,7 @@ func TestBuildAndWriteOut(t *testing.T) {
 		panic(err)
 	}
 
-	dist, err := Build(src, dstBuild, title, url)
+	files, dist, err := Build(src, dstBuild, title, url)
 	if err != nil {
 		panic(err)
 	}
@@ -409,7 +409,7 @@ func TestBuildAndWriteOut(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	err = GenerateMetadata(url, dstBuild, dist, stat.ModTime())
+	err = GenerateMetadata(src, dstBuild, url, files, dist, stat.ModTime())
 	if err != nil {
 		panic(err)
 	}

--- a/x.go
+++ b/x.go
@@ -36,6 +36,11 @@ func FileIs(f os.FileInfo, mode fs.FileMode) bool {
 	return f.Mode()&mode != 0
 }
 
+func ChangeExt(path, old, new string) string {
+	path = strings.TrimSuffix(path, old)
+	return path + new
+}
+
 func (s Set) Insert(v string) bool {
 	_, ok := s[v]
 	s[v] = struct{}{}


### PR DESCRIPTION
- Refactor index generator
- Add changes from https://github.com/soyart/ssg/pull/15
    - Fix paths in `${dst}/.files`
    - Track output originator
    - GitHub workflows now test soyweb, and tests now check for Go race conditions