### PR TITLE
Fix bad entries in .files output

### DIFF
--- a/generate.go
+++ b/generate.go
@@ -61,7 +61,7 @@ func generate(s *Ssg) error {
 		outputs[i] = Output(written[i], nil, 0)
 	}
 
-	err = GenerateMetadata(s.Url, s.Dst, outputs, stat.ModTime())
+	err = GenerateMetadata(s.Src, s.Dst, s.Url, s.files, outputs, stat.ModTime())
 	if err != nil {
 		return err
 	}

--- a/generate_test.go
+++ b/generate_test.go
@@ -23,7 +23,7 @@ func generateCaching(s *Ssg) error {
 	if err != nil {
 		return err
 	}
-	err = GenerateMetadata(s.Url, s.Dst, dist, stat.ModTime())
+	err = GenerateMetadata(s.Src, s.Dst, s.Url, s.files, dist, stat.ModTime())
 	if err != nil {
 		return err
 	}

--- a/ssg_test.go
+++ b/ssg_test.go
@@ -392,12 +392,13 @@ func TestBuildAndWriteOut(t *testing.T) {
 		panic(err)
 	}
 
-	err = Generate(src, dstGenerate, title, url)
+	sGenerate := New(src, dstGenerate, title, url)
+	err = sGenerate.Generate()
 	if err != nil {
 		panic(err)
 	}
 
-	dist, err := Build(src, dstBuild, title, url)
+	files, dist, err := Build(src, dstBuild, title, url)
 	if err != nil {
 		panic(err)
 	}
@@ -409,7 +410,7 @@ func TestBuildAndWriteOut(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	err = GenerateMetadata(url, dstBuild, dist, stat.ModTime())
+	err = GenerateMetadata(src, dstBuild, url, files, dist, stat.ModTime())
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Track file inputs and later use it to compose `${dst}/.files`.