### PR TITLE
Fix bad entries in .files output, with originator

### DIFF
--- a/.github/workflows/test-ssg-go.yaml
+++ b/.github/workflows/test-ssg-go.yaml
@@ -19,6 +19,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    env:
+      ARTIFACT_SSG_GO: "ssg-go-test_result-go${{ matrix.go-version }}_${{ matrix.os }}.json"
+      ARTIFACT_SOYWEB: "soyweb-test_result-go${{ matrix.go-version }}_${{ matrix.os }}.json"
     steps:
       - name: Checkout code
         uses: actions/checkout@master
@@ -35,18 +38,20 @@ jobs:
 
       - name: Test ssg-go
         run: |
-          go test -race -count=1 -json ./... > ssg-go-test_result-go${{ matrix.go-version }}_${{ matrix.os }}.json
+          echo Testing soyweb and writing JSON report to $ARTIFACT_SSG_GO
+          go test -race -count=1 -json ./... > $ARTIFACT_SSG_GO
 
       - name: Test soyweb
         run: |
+          echo Testing soyweb and writing JSON report to $ARTIFACT_SOYWEB
           cd ./soyweb/
-          go test -race -count=1 -json ./... > soyweb-test_result-go${{ matrix.go-version }}_${{ matrix.os }}.json
+          go test -race -count=1 -json ./... > ../$ARTIFACT_SOYWEB
 
       - name: Upload Go test results
         uses: actions/upload-artifact@v4
         with:
           name: test_result-go${{ matrix.go-version }}_${{ matrix.os }}
           path: |
-            ssg-go-test_result-go${{ matrix.go-version }}_${{ matrix.os }}.json
-            soyweb-test_result-go${{ matrix.go-version }}_${{ matrix.os }}.json
+            $ARTIFACT_SSG_GO
+            $ARTIFACT_SOYWEB
 

--- a/.github/workflows/test-ssg-go.yaml
+++ b/.github/workflows/test-ssg-go.yaml
@@ -33,12 +33,20 @@ jobs:
           cache: false
           check-latest: true
 
-      - name: Test with Go
-        run: go test -json ./... > ssg-go-test_result-go${{ matrix.go-version }}_${{ matrix.os }}.json
+      - name: Test ssg-go
+        run: |
+          go test -race -count=1 -json ./... > ssg-go-test_result-go${{ matrix.go-version }}_${{ matrix.os }}.json
+
+      - name: Test soyweb
+        run: |
+          cd ./soyweb/
+          go test -race -count=1 -json ./... > soyweb-test_result-go${{ matrix.go-version }}_${{ matrix.os }}.json
 
       - name: Upload Go test results
         uses: actions/upload-artifact@v4
         with:
-          name: ssg-go-test_result-go${{ matrix.go-version }}_${{ matrix.os }}
-          path: ssg-go-test_result-go${{ matrix.go-version }}_${{ matrix.os }}.json
+          name: test_result-go${{ matrix.go-version }}_${{ matrix.os }}
+          path: |
+            ssg-go-test_result-go${{ matrix.go-version }}_${{ matrix.os }}.json
+            soyweb-test_result-go${{ matrix.go-version }}_${{ matrix.os }}.json
 

--- a/.github/workflows/test-ssg-go.yaml
+++ b/.github/workflows/test-ssg-go.yaml
@@ -52,6 +52,6 @@ jobs:
         with:
           name: test_result-go${{ matrix.go-version }}_${{ matrix.os }}
           path: |
-            $ARTIFACT_SSG_GO
-            soyweb/$ARTIFACT_SOYWEB
+            ${{ env.ARTIFACT_SSG_GO }}
+            soyweb/${{ env.ARTIFACT_SOYWEB }}
 

--- a/.github/workflows/test-ssg-go.yaml
+++ b/.github/workflows/test-ssg-go.yaml
@@ -45,7 +45,7 @@ jobs:
         run: |
           echo Testing soyweb and writing JSON report to $ARTIFACT_SOYWEB
           cd ./soyweb/
-          go test -race -count=1 -json ./... > ../$ARTIFACT_SOYWEB
+          go test -race -count=1 -json ./... > $ARTIFACT_SOYWEB
 
       - name: Upload Go test results
         uses: actions/upload-artifact@v4
@@ -53,5 +53,5 @@ jobs:
           name: test_result-go${{ matrix.go-version }}_${{ matrix.os }}
           path: |
             $ARTIFACT_SSG_GO
-            $ARTIFACT_SOYWEB
+            soyweb/$ARTIFACT_SOYWEB
 

--- a/generate.go
+++ b/generate.go
@@ -31,7 +31,7 @@ func generate(s *Ssg) error {
 		close(s.stream)
 	}()
 
-	var written []string
+	var written []OutputFile
 	var errWrites error
 	wg.Add(1)
 	go func() {
@@ -56,12 +56,7 @@ func generate(s *Ssg) error {
 		return fmt.Errorf("streaming_write_error: %w", errWrites)
 	}
 
-	outputs := make([]OutputFile, len(written))
-	for i := range written {
-		outputs[i] = Output(written[i], nil, 0)
-	}
-
-	err = GenerateMetadata(s.Url, s.Dst, outputs, stat.ModTime())
+	err = GenerateMetadata(s.Src, s.Dst, s.Url, written, stat.ModTime())
 	if err != nil {
 		return err
 	}
@@ -71,12 +66,13 @@ func generate(s *Ssg) error {
 }
 
 // WriteOutStreaming blocks and concurrently writes outputs recevied from c until c is closed.
-func WriteOutStreaming(c <-chan OutputFile, concurrent int) ([]string, error) {
+// It returns metadata for all outputs written without the data.
+func WriteOutStreaming(c <-chan OutputFile, concurrent int) ([]OutputFile, error) {
 	if concurrent == 0 {
 		concurrent = 1
 	}
 
-	written := make([]string, 0)
+	written := make([]OutputFile, 0) // No data, only metadata
 	wg := new(sync.WaitGroup)
 	errs := make(chan writeError)
 	guard := make(chan struct{}, concurrent)
@@ -111,7 +107,7 @@ func WriteOutStreaming(c <-chan OutputFile, concurrent int) ([]string, error) {
 
 			mut.Lock()
 			defer mut.Unlock()
-			written = append(written, w.target)
+			written = append(written, Output(w.target, w.originator, nil, w.perm))
 			Fprintln(os.Stdout, w.target)
 
 		}(&o, wg)

--- a/generate.go
+++ b/generate.go
@@ -20,10 +20,13 @@ func generate(s *Ssg) error {
 	s.stream = stream
 
 	var errBuild error
+	var files []string
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_, err := s.buildV2()
+
+		var err error
+		files, _, err = s.buildV2()
 		if err != nil {
 			errBuild = err
 		}
@@ -56,7 +59,7 @@ func generate(s *Ssg) error {
 		return fmt.Errorf("streaming_write_error: %w", errWrites)
 	}
 
-	err = GenerateMetadata(s.Src, s.Dst, s.Url, written, stat.ModTime())
+	err = GenerateMetadata(s.Src, s.Dst, s.Url, files, written, stat.ModTime())
 	if err != nil {
 		return err
 	}

--- a/generate.go
+++ b/generate.go
@@ -94,22 +94,25 @@ func WriteOutStreaming(c <-chan OutputFile, concurrent int) ([]OutputFile, error
 			err := os.MkdirAll(filepath.Dir(w.target), os.ModePerm)
 			if err != nil {
 				errs <- writeError{
-					err:    err,
-					target: w.target,
+					err:        err,
+					target:     w.target,
+					originator: w.originator,
 				}
 				return
 			}
 			err = os.WriteFile(w.target, w.data, w.Perm())
 			if err != nil {
 				errs <- writeError{
-					err:    err,
-					target: w.target,
+					err:        err,
+					target:     w.target,
+					originator: w.originator,
 				}
 				return
 			}
 
 			mut.Lock()
 			defer mut.Unlock()
+
 			written = append(written, Output(w.target, w.originator, nil, w.perm))
 			Fprintln(os.Stdout, w.target)
 

--- a/generate_test.go
+++ b/generate_test.go
@@ -15,7 +15,7 @@ func generateCaching(s *Ssg) error {
 	if err != nil {
 		return err
 	}
-	dist, err := s.buildV2()
+	files, dist, err := s.buildV2()
 	if err != nil {
 		return err
 	}
@@ -23,7 +23,7 @@ func generateCaching(s *Ssg) error {
 	if err != nil {
 		return err
 	}
-	err = GenerateMetadata(s.Src, s.Dst, s.Url, dist, stat.ModTime())
+	err = GenerateMetadata(s.Src, s.Dst, s.Url, files, dist, stat.ModTime())
 	if err != nil {
 		return err
 	}

--- a/generate_test.go
+++ b/generate_test.go
@@ -23,7 +23,7 @@ func generateCaching(s *Ssg) error {
 	if err != nil {
 		return err
 	}
-	err = GenerateMetadata(s.Url, s.Dst, dist, stat.ModTime())
+	err = GenerateMetadata(s.Src, s.Dst, s.Url, dist, stat.ModTime())
 	if err != nil {
 		return err
 	}

--- a/soyweb/cmd/minifier/main.go
+++ b/soyweb/cmd/minifier/main.go
@@ -75,15 +75,16 @@ func (m *minifier) minify() ([]ssg.OutputFile, error) {
 		return m.dist, nil
 	}
 
-	output, err := soyweb.MinifyFile(m.src)
+	data, err := os.ReadFile(m.src)
 	if err != nil {
-		output, err = os.ReadFile(m.src)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
+	}
+	output, err := soyweb.MinifyAll(m.src, data)
+	if err != nil {
+		output = data
 	}
 
-	out := ssg.Output(m.dst, output, stat.Mode().Perm())
+	out := ssg.Output(m.dst, m.src, output, stat.Mode().Perm())
 	return []ssg.OutputFile{out}, nil
 }
 
@@ -110,7 +111,7 @@ func (m *minifier) walk(path string, d fs.DirEntry, e error) error {
 			return err
 		}
 
-		m.dist = append(m.dist, ssg.Output(dst, copied, info.Mode().Perm()))
+		m.dist = append(m.dist, ssg.Output(dst, path, copied, info.Mode().Perm()))
 		return nil
 	}
 
@@ -119,6 +120,6 @@ func (m *minifier) walk(path string, d fs.DirEntry, e error) error {
 		return err
 	}
 
-	m.dist = append(m.dist, ssg.Output(dst, minified, info.Mode().Perm()))
+	m.dist = append(m.dist, ssg.Output(dst, path, minified, info.Mode().Perm()))
 	return nil
 }

--- a/ssg_test.go
+++ b/ssg_test.go
@@ -137,13 +137,13 @@ Some paragraph2`,
 
 func TestGenerate(t *testing.T) {
 	t.Run("build-v2", func(t *testing.T) {
-		testGenerate(t, func(s *Ssg) ([]OutputFile, error) {
+		testGenerate(t, func(s *Ssg) ([]string, []OutputFile, error) {
 			return s.buildV2()
 		})
 	})
 }
 
-func testGenerate(t *testing.T, buildFn func(s *Ssg) ([]OutputFile, error)) {
+func testGenerate(t *testing.T, buildFn func(s *Ssg) ([]string, []OutputFile, error)) {
 	root := "./soyweb/testdata/johndoe.com"
 	src := filepath.Join(root, "/src")
 	dst := filepath.Join(root, "/dst")
@@ -156,7 +156,7 @@ func testGenerate(t *testing.T, buildFn func(s *Ssg) ([]OutputFile, error)) {
 	}
 
 	s := New(src, dst, title, url)
-	outputs, err := buildFn(&s)
+	_, outputs, err := buildFn(&s)
 	if err != nil {
 		t.Errorf("unexpected error from scan: %v", err)
 	}
@@ -397,7 +397,7 @@ func TestBuildAndWriteOut(t *testing.T) {
 		panic(err)
 	}
 
-	dist, err := Build(src, dstBuild, title, url)
+	files, dist, err := Build(src, dstBuild, title, url)
 	if err != nil {
 		panic(err)
 	}
@@ -409,7 +409,7 @@ func TestBuildAndWriteOut(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	err = GenerateMetadata(src, dstBuild, url, dist, stat.ModTime())
+	err = GenerateMetadata(src, dstBuild, url, files, dist, stat.ModTime())
 	if err != nil {
 		panic(err)
 	}

--- a/ssg_test.go
+++ b/ssg_test.go
@@ -409,7 +409,7 @@ func TestBuildAndWriteOut(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	err = GenerateMetadata(url, dstBuild, dist, stat.ModTime())
+	err = GenerateMetadata(src, dstBuild, url, dist, stat.ModTime())
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
- Track file inputs and later use it to compose ${dst}/.files.
- Track originator (file in `${src}` of each output