### PR TITLE
Release differently for branch master vs tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,8 +80,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref_name }}-${{ github.event.head_commit.timestamp }}
-          release_name: Release ${{ github.ref_name }} ${{ env.RELEASE_DATE }} ${{ github.sha }}
+          tag_name: ${{ github.ref_name }}-${{ env.RELEASE_DATE }}
+          release_name: Release ${{ github.ref_name }} for ${{ env.RELEASE_DATE }}
           draft: false
           prerelease: false
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,10 +63,6 @@ jobs:
           name: ssg-zip
           path: ./
       
-      - name: Inspect zip artifact
-        run: |
-          du -sh  ./ssg-go-x86_64_linux.zip
-
       - name: Create Release
         id: create_release
         uses: actions/create-release@master
@@ -104,11 +100,6 @@ jobs:
           name: ssg-zip
           path: ./
       
-      - name: Inspect zip artifact
-        run: |
-          ls -al ./ssg-go-x86_64_linux.zip
-          du -sh  ./ssg-go-x86_64_linux.zip
-
       - name: Get today's date
         run: |
           # Store 2025-01-01 in env $RELEASE_DATE

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,6 @@ on:
 
   push:
     branches:
-      - poc/cicd
       - master
 
     tags:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
 
   push:
     branches:
+      - poc/cicd
       - master
 
     tags:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,6 +48,53 @@ jobs:
           name: ssg-zip
           path: ./ssg-go-x86_64_linux.zip
 
+  release-branch:
+    if: ${{ github.ref_type  == 'branch' }}
+    name: Release from branch
+    needs: generate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout for release
+        uses: actions/checkout@master
+
+      - name: Download pre-built zip artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ssg-zip
+          path: ./
+      
+      - name: Inspect zip artifact
+        run: |
+          ls -al ./ssg-go-x86_64_linux.zip
+          du -sh  ./ssg-go-x86_64_linux.zip
+
+      - name: Get today's date
+        run: |
+          # Store 2025-01-01 in env $RELEASE_DATE
+          echo "RELEASE_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+      - name: Create Release for branch 
+        id: create_release
+        uses: actions/create-release@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}-${{ env.RELEASE_DATE }}-${{ github.sha }}
+          release_name: Release ${{ github.ref_name }} ${{ env.RELEASE_DATE }} ${{ github.sha }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./ssg-go-x86_64_linux.zip
+          asset_name: ssg-go-x86_64_linux.zip
+          asset_content_type: application/zip
+
   release-tag:
     if: ${{ github.ref_type  == 'tag' }}
     name: Release from tag
@@ -88,45 +135,4 @@ jobs:
           asset_path: ./ssg-go-x86_64_linux.zip
           asset_name: ssg-go-x86_64_linux.zip
           asset_content_type: application/zip
-  
-  release-branch:
-    if: ${{ github.ref_type  == 'branch' }}
-    name: Release from branch
-    needs: generate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout for release
-        uses: actions/checkout@master
 
-      - name: Download pre-built zip artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ssg-zip
-          path: ./
-      
-      - name: Get today's date
-        run: |
-          # Store 2025-01-01 in env $RELEASE_DATE
-          echo "RELEASE_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-
-      - name: Create Release for branch 
-        id: create_release
-        uses: actions/create-release@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref_name }}-${{ env.RELEASE_DATE }}-${{ github.sha }}
-          release_name: Release ${{ github.ref_name }} ${{ env.RELEASE_DATE }} ${{ github.sha }}
-          draft: false
-          prerelease: false
-
-      - name: Upload Release Asset
-        id: upload-release-asset 
-        uses: actions/upload-release-asset@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./ssg-go-x86_64_linux.zip
-          asset_name: ssg-go-x86_64_linux.zip
-          asset_content_type: application/zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
           path: ./ssg-go-x86_64_linux.zip
 
   release-tag:
-    if: ${{ github.ref_type  == tag }}
+    if: ${{ github.ref_type  == 'tag' }}
     name: Release ssg
     runs-on: ubuntu-latest
     needs: generate

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,8 +80,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref_name }}-${{ env.RELEASE_DATE }}
-          release_name: Release ${{ github.ref_name }} for ${{ env.RELEASE_DATE }}
+          tag_name: ${{ github.ref_name }}-${{ env.RELEASE_DATE }}-${{ github.sha }}
+          release_name: Release ${{ github.ref_name }} ${{ env.RELEASE_DATE }} ${{ github.sha }}
           draft: false
           prerelease: false
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,8 @@ jobs:
           name: ssg-zip
           path: ./ssg-go-x86_64_linux.zip
 
-  release:
+  release-tags:
+    if: ${{ github.ref_type  == "tag" }}
     name: Release ssg
     runs-on: ubuntu-latest
     needs: generate

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,7 +115,7 @@ jobs:
           # Store 2025-01-01 in env $RELEASE_DATE
           echo "RELEASE_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
-      - name: Create Release for branch 
+      - name: Create Release for branch ${{ github.ref_name }}
         id: create_release
         uses: actions/create-release@master
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,9 +49,54 @@ jobs:
           name: ssg-zip
           path: ./ssg-go-x86_64_linux.zip
 
+  release-branch:
+    if: ${{ github.ref_type  == 'branch' }}
+    name: Release from branch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout for release
+        uses: actions/checkout@master
+
+      - name: Download pre-built zip artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ssg-zip
+          path: ./ssg-go-x86_64_linux.zip
+      
+      - name: Inspect zip artifact
+        run: |
+          du -sh  ./ssg-go-x86_64_linux.zip
+
+      - name: Get today's date
+        run: |
+          # Store 2025-01-01 in env $RELEASE_DATE
+          echo "RELEASE_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+      - name: Create Release for branch 
+        id: create_release
+        uses: actions/create-release@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}-$RELEASE_DATE
+          release_name: Release ${{ github.ref_name }} for $RELEASE_DATE
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./ssg-go-x86_64_linux.zip
+          asset_name: ssg-go-x86_64_linux.zip
+          asset_content_type: application/zip
+
   release-tag:
     if: ${{ github.ref_type  == 'tag' }}
-    name: Release ssg
+    name: Release from tag
     runs-on: ubuntu-latest
     needs: generate
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,7 @@ jobs:
   release-branch:
     if: ${{ github.ref_type  == 'branch' }}
     name: Release from branch
+    needs: generate
     runs-on: ubuntu-latest
     steps:
       - name: Checkout for release

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,8 +80,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref_name }}-${{ env.RELEASE_DATE }}
-          release_name: Release ${{ github.ref_name }} for ${{ env.RELEASE_DATE }}
+          tag_name: ${{ github.ref_name }}-${{ github.event.head_commit.timestamp }}
+          release_name: Release ${{ github.ref_name }} ${{ env.RELEASE_DATE }} ${{ github.sha }}
           draft: false
           prerelease: false
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,6 +49,47 @@ jobs:
           name: ssg-zip
           path: ./ssg-go-x86_64_linux.zip
 
+  release-tag:
+    if: ${{ github.ref_type  == 'tag' }}
+    name: Release from tag
+    runs-on: ubuntu-latest
+    needs: generate
+    steps:
+      - name: Checkout for release
+        uses: actions/checkout@master
+
+      - name: Download pre-built zip artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ssg-zip
+          path: ./
+      
+      - name: Inspect zip artifact
+        run: |
+          du -sh  ./ssg-go-x86_64_linux.zip
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./ssg-go-x86_64_linux.zip
+          asset_name: ssg-go-x86_64_linux.zip
+          asset_content_type: application/zip
+
   release-branch:
     if: ${{ github.ref_type  == 'branch' }}
     name: Release from branch
@@ -82,47 +123,6 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}-${{ env.RELEASE_DATE }}-${{ github.sha }}
           release_name: Release ${{ github.ref_name }} ${{ env.RELEASE_DATE }} ${{ github.sha }}
-          draft: false
-          prerelease: false
-
-      - name: Upload Release Asset
-        id: upload-release-asset 
-        uses: actions/upload-release-asset@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./ssg-go-x86_64_linux.zip
-          asset_name: ssg-go-x86_64_linux.zip
-          asset_content_type: application/zip
-
-  release-tag:
-    if: ${{ github.ref_type  == 'tag' }}
-    name: Release from tag
-    runs-on: ubuntu-latest
-    needs: generate
-    steps:
-      - name: Checkout for release
-        uses: actions/checkout@master
-
-      - name: Download pre-built zip artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ssg-zip
-          path: ./
-      
-      - name: Inspect zip artifact
-        run: |
-          du -sh  ./ssg-go-x86_64_linux.zip
-
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
           draft: false
           prerelease: false
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,8 +49,8 @@ jobs:
           name: ssg-zip
           path: ./ssg-go-x86_64_linux.zip
 
-  release-tags:
-    if: ${{ github.ref_type  == "tag" }}
+  release-tag:
+    if: ${{ github.ref_type  == tag }}
     name: Release ssg
     runs-on: ubuntu-latest
     needs: generate

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,10 +62,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ssg-zip
-          path: ./ssg-go-x86_64_linux.zip
+          path: ./
       
       - name: Inspect zip artifact
         run: |
+          ls -al ./ssg-go-x86_64_linux.zip
           du -sh  ./ssg-go-x86_64_linux.zip
 
       - name: Get today's date
@@ -108,7 +109,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: ssg-zip
-          path: ./ssg-go-x86_64_linux.zip
+          path: ./
       
       - name: Inspect zip artifact
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,8 +79,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref_name }}-$RELEASE_DATE
-          release_name: Release ${{ github.ref_name }} for $RELEASE_DATE
+          tag_name: ${{ github.ref_name }}-${{ env.RELEASE_DATE }}
+          release_name: Release ${{ github.ref_name }} for ${{ env.RELEASE_DATE }}
           draft: false
           prerelease: false
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,53 +49,6 @@ jobs:
           name: ssg-zip
           path: ./ssg-go-x86_64_linux.zip
 
-  release-branch:
-    if: ${{ github.ref_type  == 'branch' }}
-    name: Release from branch
-    needs: generate
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout for release
-        uses: actions/checkout@master
-
-      - name: Download pre-built zip artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: ssg-zip
-          path: ./
-      
-      - name: Inspect zip artifact
-        run: |
-          ls -al ./ssg-go-x86_64_linux.zip
-          du -sh  ./ssg-go-x86_64_linux.zip
-
-      - name: Get today's date
-        run: |
-          # Store 2025-01-01 in env $RELEASE_DATE
-          echo "RELEASE_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-
-      - name: Create Release for branch 
-        id: create_release
-        uses: actions/create-release@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref_name }}-${{ env.RELEASE_DATE }}-${{ github.sha }}
-          release_name: Release ${{ github.ref_name }} ${{ env.RELEASE_DATE }} ${{ github.sha }}
-          draft: false
-          prerelease: false
-
-      - name: Upload Release Asset
-        id: upload-release-asset 
-        uses: actions/upload-release-asset@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
-          asset_path: ./ssg-go-x86_64_linux.zip
-          asset_name: ssg-go-x86_64_linux.zip
-          asset_content_type: application/zip
-
   release-tag:
     if: ${{ github.ref_type  == 'tag' }}
     name: Release from tag
@@ -136,4 +89,45 @@ jobs:
           asset_path: ./ssg-go-x86_64_linux.zip
           asset_name: ssg-go-x86_64_linux.zip
           asset_content_type: application/zip
+  
+  release-branch:
+    if: ${{ github.ref_type  == 'branch' }}
+    name: Release from branch
+    needs: generate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout for release
+        uses: actions/checkout@master
 
+      - name: Download pre-built zip artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ssg-zip
+          path: ./
+      
+      - name: Get today's date
+        run: |
+          # Store 2025-01-01 in env $RELEASE_DATE
+          echo "RELEASE_DATE=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+      - name: Create Release for branch 
+        id: create_release
+        uses: actions/create-release@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}-${{ env.RELEASE_DATE }}-${{ github.sha }}
+          release_name: Release ${{ github.ref_name }} ${{ env.RELEASE_DATE }} ${{ github.sha }}
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ./ssg-go-x86_64_linux.zip
+          asset_name: ssg-go-x86_64_linux.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,8 @@ on:
 
   push:
     branches:
-      - 'poc/cicd'
+      - poc/cicd
+      - master
 
     tags:
       - 'v*'
@@ -15,10 +16,10 @@ on:
 name: Release ssg-go
 jobs:
   generate:
-    name: Build and release
+    name: Build ssg
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout the repository
+      - name: Checkout for build
         uses: actions/checkout@master
 
       - name: Install Nix
@@ -42,6 +43,30 @@ jobs:
         run: |
           zip -r ssg-go-x86_64_linux.zip result/bin
 
+      - name: Upload artifact
+        uses: actions/upload-artifact@master
+        with:
+          name: ssg-zip
+          path: ./ssg-go-x86_64_linux.zip
+
+  release:
+    name: Release ssg
+    runs-on: ubuntu-latest
+    needs: generate
+    steps:
+      - name: Checkout for release
+        uses: actions/checkout@master
+
+      - name: Download pre-built zip artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ssg-zip
+          path: ./ssg-go-x86_64_linux.zip
+      
+      - name: Inspect zip artifact
+        run: |
+          du -sh  ./ssg-go-x86_64_linux.zip
+
       - name: Create Release
         id: create_release
         uses: actions/create-release@master
@@ -63,3 +88,4 @@ jobs:
           asset_path: ./ssg-go-x86_64_linux.zip
           asset_name: ssg-go-x86_64_linux.zip
           asset_content_type: application/zip
+


### PR DESCRIPTION
Previously we only use release.yaml to release from tags. This is because the variables we were using had some `refs/head/` or `refs/tags/` prefixes, and GitHub does not allow these in Release's tag name.

To fix this, we'll release differently for branches and tags.

Tags will be released like as-is, while branches will have fancier release tag names to avoid collisions