### PR TITLE
Refactor output stream handling

### DIFF
--- a/ssg-go/build.go
+++ b/ssg-go/build.go
@@ -1,0 +1,85 @@
+package ssg
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+)
+
+func build(s *Ssg, o Outputs) ([]string, []OutputFile, error) {
+	s.result = buildOutput{
+		cacheOutput: s.options.caching,
+		writer:      o,
+	}
+	err := filepath.WalkDir(s.Src, s.walk)
+	if err != nil {
+		return nil, nil, err
+	}
+	return s.result.files, s.result.cache, nil
+}
+
+func (s *Ssg) walk(path string, d fs.DirEntry, err error) error {
+	if err != nil {
+		return err
+	}
+	if d.IsDir() {
+		return s.collect(path)
+	}
+
+	base := filepath.Base(path)
+	ignore, err := shouldIgnore(s.ssgignores, path, base, d)
+	if err != nil {
+		return err
+	}
+	if ignore {
+		return nil
+	}
+
+	switch base {
+	case
+		MarkerHeader,
+		MarkerFooter,
+		SsgIgnore:
+
+		return nil
+	}
+
+	data, err := ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	// Remember input files for .files
+	//
+	// Original ssg does not include _header.html
+	// and _footer.html in .files
+	s.result.files = append(s.result.files, path)
+
+	skipCore := false
+	for i, p := range s.options.pipelines {
+		path, data, d, err = p(path, data, d)
+		if err == nil {
+			continue
+		}
+		if errors.Is(err, ErrSkipCore) {
+			skipCore = true
+			break
+		}
+		if errors.Is(err, ErrBreakPipelines) {
+			break
+		}
+		return fmt.Errorf("[pipeline %d] error: %w", i, err)
+	}
+
+	if skipCore {
+		return nil
+	}
+
+	output, err := s.core(path, data, d)
+	if err != nil {
+		return fmt.Errorf("core error: %w", err)
+	}
+	s.result.Add(output)
+	return nil
+}

--- a/ssg-go/common.go
+++ b/ssg-go/common.go
@@ -10,6 +10,10 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/gomarkdown/markdown"
+	"github.com/gomarkdown/markdown/html"
+	"github.com/gomarkdown/markdown/parser"
 )
 
 type (
@@ -35,6 +39,15 @@ type (
 		perDir[*bytes.Buffer]
 	}
 )
+
+// ToHtml converts md (Markdown) into HTML document
+func ToHtml(md []byte) []byte {
+	root := markdown.Parse(md, parser.NewWithExtensions(SsgExtensions))
+	renderer := html.NewRenderer(html.RendererOptions{
+		Flags: HtmlFlags,
+	})
+	return markdown.Render(root, renderer)
+}
 
 func FileIs(f os.FileInfo, mode fs.FileMode) bool {
 	return f.Mode()&mode != 0

--- a/ssg-go/common.go
+++ b/ssg-go/common.go
@@ -13,18 +13,6 @@ import (
 )
 
 type (
-	// OutputFile is the main output struct for ssg-go.
-	//
-	// Its values are not supposed to be changed by other packages,
-	// and thus the only ways other packages can work with OutputFile
-	// is via the constructor [Output] and the type's getter methods.
-	OutputFile struct {
-		target     string
-		originator string
-		data       []byte
-		perm       fs.FileMode
-	}
-
 	Set map[string]struct{}
 
 	// perDir tracks files under directory in a trie-like fashion.
@@ -73,30 +61,28 @@ func (s Set) Contains(items ...string) bool {
 	return true
 }
 
-func Fprint(w io.Writer, data ...interface{}) {
+func Fprint(w io.Writer, data ...any) {
 	_, err := fmt.Fprint(w, data...)
 	if err != nil {
 		panic(err)
 	}
 }
 
-func Fprintf(w io.Writer, format string, data ...interface{}) {
+func Fprintf(w io.Writer, format string, data ...any) {
 	_, err := fmt.Fprintf(w, format, data...)
 	if err != nil {
 		panic(err)
 	}
 }
 
-func Fprintln(w io.Writer, data ...interface{}) {
+func Fprintln(w io.Writer, data ...any) {
 	_, err := fmt.Fprintln(w, data...)
 	if err != nil {
 		panic(err)
 	}
 }
 
-// For debugging
 func ReadFile(path string) ([]byte, error) {
-	// fmt.Println(">>> reading file", path)
 	return os.ReadFile(path)
 }
 

--- a/ssg-go/generate.go
+++ b/ssg-go/generate.go
@@ -16,8 +16,6 @@ func generate(s *Ssg) error {
 	}
 
 	stream := make(chan OutputFile, s.options.writers*bufferMultiplier)
-	s.SetOutputStream(stream)
-
 	var wg sync.WaitGroup
 	wg.Add(2)
 
@@ -25,13 +23,12 @@ func generate(s *Ssg) error {
 	var files []string
 	go func() {
 		defer func() {
-			s.ClearOutputStream()
 			close(stream)
 			wg.Done()
 		}()
 
 		var err error
-		files, _, err = s.buildV2()
+		files, _, err = s.buildV2(stream)
 		if err != nil {
 			errBuild = err
 		}

--- a/ssg-go/generate.go
+++ b/ssg-go/generate.go
@@ -29,7 +29,7 @@ func generate(s *Ssg) error {
 		}()
 
 		var err error
-		files, _, err = s.build(outputs)
+		files, _, err = s.Build(outputs)
 		if err != nil {
 			errBuild = err
 		}

--- a/ssg-go/generate.go
+++ b/ssg-go/generate.go
@@ -16,6 +16,8 @@ func generate(s *Ssg) error {
 	}
 
 	stream := make(chan OutputFile, s.options.writers*bufferMultiplier)
+	outputs := NewOutputs(stream)
+
 	var wg sync.WaitGroup
 	wg.Add(2)
 
@@ -28,7 +30,7 @@ func generate(s *Ssg) error {
 		}()
 
 		var err error
-		files, _, err = s.buildV2(stream)
+		files, _, err = s.buildV2(outputs)
 		if err != nil {
 			errBuild = err
 		}

--- a/ssg-go/generate_test.go
+++ b/ssg-go/generate_test.go
@@ -35,7 +35,7 @@ func TestGenerateStreaming(t *testing.T) {
 	// (old v2 flow)
 	caching := New(src, dst, title, url)
 	caching.With(
-		Caching(),
+		Caching(true),
 		Writers(uint(WritersDefault)),
 	)
 

--- a/ssg-go/options.go
+++ b/ssg-go/options.go
@@ -35,6 +35,7 @@ type (
 	}
 
 	options struct {
+		// outputs      Outputs
 		hooks        []Hook
 		hookGenerate []HookGenerate
 		pipelines    []Pipeline
@@ -80,6 +81,10 @@ func Caching() Option {
 func Writers(u uint) Option {
 	return func(s *Ssg) { s.options.writers = int(u) }
 }
+
+// func WithOutputs(c chan<- OutputFile) Option {
+// 	return func(s *Ssg) { s.options.outputs = NewOutputs(c) }
+// }
 
 // WithHooks will make [Ssg] iterate through hooks and call hook(path, fileContent)
 // on every unignored files.

--- a/ssg-go/options.go
+++ b/ssg-go/options.go
@@ -73,8 +73,8 @@ func GetEnvWriters() int {
 
 // Caching allows outputs to be built and retained for later use.
 // This is enabled in [Build].
-func Caching() Option {
-	return func(s *Ssg) { s.options.caching = true }
+func Caching(b bool) Option {
+	return func(s *Ssg) { s.options.caching = b }
 }
 
 // Writers set the number of concurrent output writers.

--- a/ssg-go/options_test.go
+++ b/ssg-go/options_test.go
@@ -70,19 +70,18 @@ func TestPrependHooks(t *testing.T) {
 		opts = append(opts, original, prepend)
 
 		s := new(ssg.Ssg)
-		s.With(original, prepend)
+		s.With(opts...)
 		assert(t, s)
 	})
 
 	t.Run("option slice rev", func(t *testing.T) {
 		var opts []ssg.Option
 		original := ssg.WithHooks(hook3, hook4)
-		opts = append(opts, original)
 		prepend := ssg.PrependHooks(hook1, hook2)
 		opts = append(opts, prepend, original)
 
 		s := new(ssg.Ssg)
-		s.With(original, prepend)
+		s.With(opts...)
 		assert(t, s)
 	})
 }

--- a/ssg-go/options_test.go
+++ b/ssg-go/options_test.go
@@ -109,8 +109,7 @@ func inputHasher(s *ssg.Ssg) ssg.Pipeline {
 			return path, data, d, nil
 		}
 
-		s.AddOutputs(ssg.Output(hashPath, path, []byte(hash), 0o644))
-
+		s.Outputs().Add(ssg.Output(hashPath, path, []byte(hash), 0o644))
 		return path, data, d, nil
 	}
 }

--- a/ssg-go/output.go
+++ b/ssg-go/output.go
@@ -1,19 +1,52 @@
 package ssg
 
+import "io/fs"
+
+// OutputFile is the main output struct for ssg-go.
+//
+// Its values are not supposed to be changed by other packages,
+// and thus the only ways other packages can work with OutputFile
+// is via the constructor [Output] and the type's getter methods.
+type OutputFile struct {
+	target     string
+	originator string
+	data       []byte
+	perm       fs.FileMode
+}
+
+// Outputs is any collection out OutputFile.
+// It could be a simple Go slice that later get iterated and written to disk,
+// or a channel (as with outputsV1)
 type Outputs interface {
-	AddOutputs(...OutputFile)
+	Add(...OutputFile)
 }
 
 type outputsV1 struct {
 	stream chan<- OutputFile
 }
 
-func NewOutputs(c chan<- OutputFile) Outputs {
+type buildOutput struct {
+	cacheOutput bool
+	writer      Outputs      // Main outputs
+	files       []string     // Input files read (not ignored)
+	cache       []OutputFile // Cache of main outputs
+}
+
+func NewOutputsStreaming(c chan<- OutputFile) Outputs {
 	return outputsV1{stream: c}
 }
 
-func (o outputsV1) AddOutputs(outputs ...OutputFile) {
+func (o outputsV1) Add(outputs ...OutputFile) {
 	for i := range outputs {
 		o.stream <- outputs[i]
+	}
+}
+
+func (b *buildOutput) Add(outputs ...OutputFile) {
+	if b.cacheOutput {
+		b.cache = append(b.cache, outputs...)
+	}
+	if b.writer != nil {
+		b.writer.Add(outputs...)
 	}
 }

--- a/ssg-go/output.go
+++ b/ssg-go/output.go
@@ -1,0 +1,19 @@
+package ssg
+
+type Outputs interface {
+	AddOutputs(...OutputFile)
+}
+
+type outputsV1 struct {
+	stream chan<- OutputFile
+}
+
+func NewOutputs(c chan<- OutputFile) Outputs {
+	return outputsV1{stream: c}
+}
+
+func (o outputsV1) AddOutputs(outputs ...OutputFile) {
+	for i := range outputs {
+		o.stream <- outputs[i]
+	}
+}

--- a/ssg-go/ssg.go
+++ b/ssg-go/ssg.go
@@ -146,6 +146,20 @@ func (s *Ssg) AddOutputs(outputs ...OutputFile) {
 	}
 }
 
+func (s *Ssg) SetOutputStream(c chan<- OutputFile) {
+	if s.stream != nil {
+		panic(fmt.Sprintf("existing stream exists: %v", s.stream))
+	}
+	s.stream = c
+}
+
+func (s *Ssg) ClearOutputStream() {
+	if s.stream == nil {
+		panic("stream is nil")
+	}
+	s.stream = nil
+}
+
 func (s *Ssg) buildV2() ([]string, []OutputFile, error) {
 	err := filepath.WalkDir(s.Src, s.walkBuildV2)
 	if err != nil {

--- a/ssg-go/ssg.go
+++ b/ssg-go/ssg.go
@@ -74,8 +74,8 @@ func (s *Ssg) Options() Options { return s.options }
 func Build(src, dst, title, url string, opts ...Option) ([]string, []OutputFile, error) {
 	s := New(src, dst, title, url)
 	return s.
+		With(Caching(true)).
 		With(opts...).
-		With(Caching()).
 		buildV2(nil)
 }
 

--- a/ssg-go/ssg_test.go
+++ b/ssg-go/ssg_test.go
@@ -140,7 +140,7 @@ Some paragraph2`,
 func TestGenerate(t *testing.T) {
 	t.Run("build-v2", func(t *testing.T) {
 		testGenerate(t, func(s *Ssg) ([]string, []OutputFile, error) {
-			return s.buildV2()
+			return s.buildV2(s.stream)
 		})
 	})
 }

--- a/ssg-go/ssg_test.go
+++ b/ssg-go/ssg_test.go
@@ -140,7 +140,7 @@ Some paragraph2`,
 func TestGenerate(t *testing.T) {
 	t.Run("build-v2", func(t *testing.T) {
 		testGenerate(t, func(s *Ssg) ([]string, []OutputFile, error) {
-			return s.build(nil)
+			return s.Build(nil)
 		})
 	})
 }
@@ -393,8 +393,8 @@ func TestBuildAndWriteOut(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	// Build output
-	files, cache, err := Build(src, dstBuild, title, url)
+	// Build with nil outputs (no concurrent writer)
+	files, cache, err := Build(src, dstBuild, title, url, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/ssg-go/ssg_test.go
+++ b/ssg-go/ssg_test.go
@@ -186,7 +186,7 @@ func testGenerate(t *testing.T, buildFn func(s *Ssg) ([]string, []OutputFile, er
 	for h, from := range titleFroms {
 		filename := filepath.Join(src, h)
 		dirname := filepath.Dir(filename)
-		header, ok := s.headers.perDir.values[dirname]
+		header, ok := s.headers.values[dirname]
 		if !ok {
 			t.Fatalf("missing header '%s' for dir '%s'", filename, dirname)
 		}
@@ -375,8 +375,8 @@ func TestSsgignore(t *testing.T) {
 	}
 }
 
-// TestBuildAndWriteOut tests that Build+WriteOut functions
-// work as expected (identical to streaming Generate)
+// TestBuildAndWriteOut tests that Build+WriteOut both
+// work as expected (identical to Generate)
 func TestBuildAndWriteOut(t *testing.T) {
 	root := "../testdata/johndoe.com"
 	src := filepath.Join(root, "/src")
@@ -393,17 +393,12 @@ func TestBuildAndWriteOut(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-
-	err = Generate(src, dstGenerate, title, url)
+	// Build output
+	files, cache, err := Build(src, dstBuild, title, url)
 	if err != nil {
 		panic(err)
 	}
-
-	files, dist, err := Build(src, dstBuild, title, url)
-	if err != nil {
-		panic(err)
-	}
-	err = WriteOutSlice(dist, 1)
+	err = WriteOutSlice(cache, 1)
 	if err != nil {
 		panic(err)
 	}
@@ -411,11 +406,16 @@ func TestBuildAndWriteOut(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	err = GenerateMetadata(src, dstBuild, url, files, dist, stat.ModTime())
+	err = GenerateMetadata(src, dstBuild, url, files, cache, stat.ModTime())
 	if err != nil {
 		panic(err)
 	}
-
+	// Generate output
+	err = Generate(src, dstGenerate, title, url)
+	if err != nil {
+		panic(err)
+	}
+	// Assert equal
 	testDeepEqual(t, dstGenerate, dstBuild)
 }
 

--- a/ssg-go/ssg_test.go
+++ b/ssg-go/ssg_test.go
@@ -140,7 +140,7 @@ Some paragraph2`,
 func TestGenerate(t *testing.T) {
 	t.Run("build-v2", func(t *testing.T) {
 		testGenerate(t, func(s *Ssg) ([]string, []OutputFile, error) {
-			return s.buildV2(s.stream)
+			return s.buildV2(nil)
 		})
 	})
 }

--- a/ssg-go/ssg_test.go
+++ b/ssg-go/ssg_test.go
@@ -140,7 +140,7 @@ Some paragraph2`,
 func TestGenerate(t *testing.T) {
 	t.Run("build-v2", func(t *testing.T) {
 		testGenerate(t, func(s *Ssg) ([]string, []OutputFile, error) {
-			return s.buildV2(nil)
+			return s.build(nil)
 		})
 	})
 }
@@ -166,8 +166,8 @@ func testGenerate(t *testing.T, buildFn func(s *Ssg) ([]string, []OutputFile, er
 		t.Fatalf("missing preferred html file /blog/index.html")
 	}
 
-	for i := range s.cache {
-		o := &s.cache[i]
+	for i := range s.result.cache {
+		o := &s.result.cache[i]
 
 		if strings.HasSuffix(o.target, "_header.html") {
 			t.Fatalf("unexpected _header.html output in '%s'", o.target)


### PR DESCRIPTION
Our internal API hides output stream management from most method/function signatures. This PR makes sure that we always know about the output stream at any level